### PR TITLE
fixes a kwarg error for `ssl` parameter

### DIFF
--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -71,6 +71,7 @@ class SSLClusterConnection(SSLConnection):
     def __init__(self, **kwargs):
         self.readonly = kwargs.pop('readonly', False)
         kwargs['parser_class'] = ClusterParser
+        kwargs.pop('ssl', False)
         super(SSLClusterConnection, self).__init__(**kwargs)
 
     def on_connect(self):


### PR DESCRIPTION
fixes this:
```
Traceback (most recent call last):
  File "/opt/.../site-packages/dd/utils/.../base_redis_cluster_cache.py", line 163, in set
    self._cluster.setex(k, expire_in_sec, v)
  File "/opt/.../site-packages/redis/client.py", line 1822, in setex
    return self.execute_command('SETEX', name, time, value)
  File "/opt/.../site-packages/ddtrace/contrib/redis/patch.py", line 80, in traced_execute_command
    return func(*args, **kwargs)
  File "/opt/.../site-packages/rediscluster/client.py", line 537, in execute_command
    return self._execute_command(*args, **kwargs)
  File "/opt/.../site-packages/rediscluster/client.py", line 590, in _execute_command
    connection = self.connection_pool.get_connection_by_node(node)
  File "/opt/.../site-packages/rediscluster/connection.py", line 320, in get_connection_by_node
    connection = self.make_connection(node)
  File "/opt/.../site-packages/rediscluster/connection.py", line 227, in make_connection
    connection = self.connection_class(host=node["host"], port=node["port"], **self.connection_kwargs)
  File "/opt/..../site-packages/rediscluster/connection.py", line 74, in __init__
    super(SSLClusterConnection, self).__init__(**kwargs)
  File "/opt/.../site-packages/redis/connection.py", line 819, in __init__
    super(SSLConnection, self).__init__(**kwargs)
TypeError: __init__() got an unexpected keyword argument 'ssl'
Exception AttributeError: "'SSLClusterConnection' object has no attribute '_parser'" in <object repr() failed> ignored
```

it turns out that the `connection_kwargs` that are used in 2 places.
1. https://github.com/DataDog/redis-py-cluster/blob/unstable/rediscluster/connection.py#L127 sets this `ssl` parameter to `True`
2. SSLClusterConnection inherits from SSLConnection which inherits from Connection (none of these have `ssl` kwarg rendering this exception
3. **but** `Redis` client has an `ssl` kwarg that is used correctly: https://github.com/DataDog/redis-py-cluster/blob/unstable/rediscluster/nodemanager.py#L166 here in the NodeManager