### PR TITLE
Fix connection get pool

### DIFF
--- a/rediscluster/connection.py
+++ b/rediscluster/connection.py
@@ -581,7 +581,7 @@ class ClusterWithReadReplicasConnectionPool(ClusterConnectionPool):
     Custom connection pool for rediscluster with load balancing across read replicas
     """
 
-    def get_node_by_slot(self, slot, read_command=False):
+    def get_node_by_slot(self, slot, read_command=False, *args, **kwargs):
         """
         Get a random node from the slot, including master
         """


### PR DESCRIPTION
On the ReadOnlyClusterCOnnectionPool it doesn't have the *args, **kwargs and it seems the client is passing down some extra unneeded args. Just ignore them.